### PR TITLE
#14 Update packages, explore vue3-jest options

### DIFF
--- a/packages/vue3-vite/src/defaults.ts
+++ b/packages/vue3-vite/src/defaults.ts
@@ -1,25 +1,27 @@
 
 // dependency versions
 export const vueVersion = '^3.2.1';
-export const vueI18nVersion = '^9.1.6';
-export const vueRouterVersion = '^4.0.10';
+export const vueI18nVersion = '^9.2.0-beta.2';
+export const vueRouterVersion = '^4.0.11';
 export const dateFnsVersion = '^2.23.0';
-export const fetchApiVersion = '^0.3.2';
+export const fetchApiVersion = '^0.4.0';
 
 // devDependency versions
 export const viteVersion = '^2.4.4';
 export const eslintVersion = '^7.32.0';
 export const eslintI18nVersion = '^0.12.0';
-export const eslintImportVersion = '^2.23.4';
-export const eslintVueVersion = '^7.15.0';
-export const babelCommonjsVersion = '^7.14.5';
+export const eslintImportVersion = '^2.24.0';
+export const eslintVueVersion = '^7.16.0';
+export const babelCommonjsVersion = '^7.15.0';
 export const chalkVersion = '^4.1.2';
 export const convertSourceMapVersion = '^1.8.0';
 export const extractCSSVersion = '^0.4.4';
 export const sourceMapVersion = '^0.7.3';
-export const vuePluginVersion = '^1.3.0';
+export const vuePluginVersion = '^1.4.0';
 export const vueTestUtilsVersion = '^2.0.0-rc.12';
-export const vue3JestVersion = '^27.0.0-alpha.2';
+// TODO -- add or remove once it's out of alpha or vite-jest is used
+// https://github.com/samatechtw/nx-vue3-vite/issues/14
+// export const vue3JestVersion = '^27.0.0-alpha.2';
 export const postcssVersion = '^8.3.6';
 export const postcssBasicsVersion = '^0.2.0';
 export const compilerSfcVersion = vueVersion;
@@ -53,7 +55,7 @@ export const DevDependencies = {
   postcss: postcssVersion,
   '@vitejs/plugin-vue': vuePluginVersion,
   '@vue/test-utils': vueTestUtilsVersion,
-  'vue3-jest': vue3JestVersion,
+   // 'vue3-jest': vue3JestVersion,
   '@samatech/postcss-basics': postcssBasicsVersion,
   stylelint: stylelintVersion,
   'stylelint-config-standard': stylelintConfigVersion,


### PR DESCRIPTION
WIP #14 

Until `vue3-jest` or `vite-jest` is more stable, the current solution of keeping `vue3-jest` in-tree is the best option.